### PR TITLE
Fixes Null object

### DIFF
--- a/packages/core/src/objects/Dictionary.ts
+++ b/packages/core/src/objects/Dictionary.ts
@@ -127,6 +127,17 @@ export class PDFDictionary extends PDFObject {
       res.ownerElement = this;
     }
 
+
+    if (type && res instanceof PDFNull) {
+      const newRes = type.create(this.documentUpdate) as PDFObjectTypes;
+      if (newRes.isIndirect()) {
+        newRes.makeIndirect();
+      }
+      res = newRes;
+
+      this.set(name, res);
+    }
+
     const resType = PDFTypeConverter.convert(res, type, replace);
     if (replace && !resType.isIndirect) {
       this.set(name, resType as PDFObjectTypes);

--- a/packages/core/src/objects/Maybe.ts
+++ b/packages/core/src/objects/Maybe.ts
@@ -1,15 +1,16 @@
 import type { PDFDictionary } from "./Dictionary";
+import { PDFNull } from "./Null";
 
 export class Maybe<T extends PDFObject> {
 
   constructor(
-    public parent: PDFDictionary, 
-    public name: string, 
+    public parent: PDFDictionary,
+    public name: string,
     public indirect: boolean,
     private _type: PDFObjectConstructor<T>) { }
 
   public get(required = false): T {
-    if (!this.parent.has(this.name)) {
+    if (!this.parent.has(this.name) || this.parent.get(this.name) instanceof PDFNull) {
       if (required) {
         throw new Error(`Cannot get required field '${this.name}'. Field is empty.`);
       }

--- a/packages/core/src/structure/DocumentObject.ts
+++ b/packages/core/src/structure/DocumentObject.ts
@@ -1,8 +1,9 @@
-import { PDFIndirectObject, PDFIndirectReference, PDFObject } from "../objects";
+import { PDFIndirectObject, PDFIndirectReference, PDFNull, PDFObject } from "../objects";
 import { CompressedObject } from "./CompressedObject";
 import type { PDFDocumentUpdate } from "./DocumentUpdate";
 
 export enum PDFDocumentObjectTypes {
+  null = "z",
   free = "f",
   inUse = "n",
   compressed = "c",
@@ -103,7 +104,14 @@ export class PDFDocumentObject implements PDFDocumentObjectParameters {
       if (!this.documentUpdate.document) {
         throw new Error("Required field 'document' is missing");
       }
-      if (this.type === PDFDocumentObjectTypes.compressed) {
+      if (this.type === PDFDocumentObjectTypes.null) {
+        const value = new PDFIndirectObject();
+        value.documentUpdate = this.documentUpdate;
+        value.value = new PDFNull();
+        value.value.documentUpdate = this.documentUpdate;
+
+        this.#value = value;
+      } else if (this.type === PDFDocumentObjectTypes.compressed) {
         // Get CompressedObject stream which
         const compressedObject = this.documentUpdate.getObject(this.offset).value;
         if (!(compressedObject instanceof CompressedObject)) {

--- a/packages/core/src/structure/DocumentUpdate.ts
+++ b/packages/core/src/structure/DocumentUpdate.ts
@@ -72,7 +72,7 @@ export class PDFDocumentUpdate {
     const reader = objects.PDFObject.getReader(data, offset);
     this.startXref = reader.view.byteOffset + reader.position;
 
-    let position = 0; 
+    let position = 0;
 
     // beginning with PDF 1.5 cross-reference information may bew stored in a cross-reference stream
     if (this.document.version >= 1.5 && reader.current !== 0x78) { // x
@@ -278,7 +278,13 @@ export class PDFDocumentUpdate {
       return prev.getObject(param, generation);
     }
 
-    throw new Error(`IndirectObject '${param} ${generation}' does not exist`);
+    return new PDFDocumentObject({
+      id: 0,
+      generation: 0,
+      offset: 0,
+      type: PDFDocumentObjectTypes.null,
+      documentUpdate: this,
+    });
   }
 
   protected getCompressedObjectNumbers(): number[] {


### PR DESCRIPTION
```ts
// Null (it doesn't throw an error how it was before)
console.log(box.target.AP.get().get("N").toString());

// Null -> Dictionary (Dictionary.get method allows replacing Null objects)
box.target.AP.get().get("N", PDFDictionary);
console.log(box.target.AP.get().get("N").toString());
```