### PR TITLE
fix: Wrong appearance for Comb text fields

### DIFF
--- a/packages/doc/src/Font.ts
+++ b/packages/doc/src/Font.ts
@@ -25,7 +25,7 @@ function createFontInfo(dict: core.TrueTypeFontDictionary): pdfFont.IFontInfo {
   return {
     ascent: dict.FontDescriptor.ascent || 0,
     descent: dict.FontDescriptor.descent || 0,
-    unitsPerEm: 1,
+    unitsPerEm: 1000,
     findGlyph: (code: number): pdfFont.IFontGlyph => {
       if (!dict.Encoding) {
         throw new Error("TrueTypeFontDictionary should have Encoding field.");
@@ -225,10 +225,18 @@ export class FontComponent extends WrapObject<core.FontDictionary> {
     return width * size / 1000;
   }
 
-  public measureTextHeight(fontSize: number, descent = true): number {
+  /**
+   * Calculates the height of a text with the specified font size.
+   * @param fontSize - The size of the font in pixels.
+   * @param includeDescent - Whether to include the font's descent in the calculation.
+   * @returns The height of the text in pixels.
+   */
+  public measureTextHeight(fontSize: number, includeDescent = true): number {
     const scale = 1000 / this.fontInfo.unitsPerEm;
+    const ascent = this.fontInfo.ascent;
+    const descent = includeDescent ? this.fontInfo.descent : 0;
 
-    return (this.fontInfo.ascent - (descent ? this.fontInfo.descent : 0)) / 1000 * fontSize * scale;
+    return (ascent - descent) / 1000 * fontSize * scale;
   }
 
   private static addComposite(font: pdfFont.DefaultFonts | BufferSource, document: PDFDocument): FontComponent {

--- a/packages/doc/src/forms/TextEditor.ts
+++ b/packages/doc/src/forms/TextEditor.ts
@@ -215,7 +215,7 @@ export class TextEditor extends FormComponent {
 
       const handler = this.document.textEditorHandler;
       form.clear();
-      handler.drawText(form, params);
+      handler.drawText(form, params, this.target);
     }
   }
 }


### PR DESCRIPTION
This pull request optimizes and fixes some issues in the `Font` and `TextEditor.Handler` modules of the PDFKit library.

The `createFontInfo` function in `Font.ts` has been updated to set the `unitsPerEm` property of the font info object to 1000, which is the correct value for TrueType fonts.

In `TextEditor.Handler.ts`, the `drawText` method has been modified to fix the vertical alignment of multiline text and text with a comb field flag. The `drawText` method has also been updated to accept an additional parameter, `target`, which is used to calculate the vertical padding of the text field.

The `measureTextHeight` method in `FontComponent` has been updated to include TSDoc-style comments.

## Checklist

- [x] Updated the `createFontInfo` function to set the `unitsPerEm` property to 1000.
- [x] Modified the `drawText` method in `TextEditor.Handler.ts` to fix the vertical alignment of multiline text and text with a comb field flag.
- [x] Updated the `measureTextHeight` method in `FontComponent` to include TSDoc-style comments.
- [x] Tested the changes and ensured that the tests pass.
- [x] Updated the documentation and/or examples if necessary.
- [x] Fixes #60
