### PR TITLE
fix Can't update exists fields because of font errors

### DIFF
--- a/packages/core/src/structure/dictionaries/Type1FontDictionary.ts
+++ b/packages/core/src/structure/dictionaries/Type1FontDictionary.ts
@@ -1,4 +1,4 @@
-import { PDFArray, PDFArrayField, PDFDictionary, PDFDictionaryField, PDFNameField, PDFNumberField, PDFStream } from "../../objects";
+import { PDFArray, PDFArrayField, PDFDictionary, PDFDictionaryField, PDFName, PDFNameField, PDFNumberField, PDFStream } from "../../objects";
 import { FontDictionary } from "./FontDictionary";
 
 export class Type1FontDictionary extends FontDictionary {
@@ -64,10 +64,9 @@ export class Type1FontDictionary extends FontDictionary {
    */
   @PDFDictionaryField({
     name: "Encoding",
-    type: PDFDictionary,
     optional: true,
   })
-  public Encoding!: PDFDictionary | null;
+  public Encoding!: PDFDictionary | PDFName | null;
 
   /**
    * (Optional; PDF 1.2) A stream containing a CMap file that maps character

--- a/packages/doc/src/Font.ts
+++ b/packages/doc/src/Font.ts
@@ -21,7 +21,7 @@ export interface CMapsParams {
   glyphs: pdfFont.FontGlyph[];
 }
 
-function createFontInfo(dict: core.TrueTypeFontDictionary): pdfFont.IFontInfo {
+function createFontInfoFromTrueType(dict: core.TrueTypeFontDictionary): pdfFont.IFontInfo {
   return {
     ascent: dict.FontDescriptor.ascent || 0,
     descent: dict.FontDescriptor.descent || 0,
@@ -33,6 +33,50 @@ function createFontInfo(dict: core.TrueTypeFontDictionary): pdfFont.IFontInfo {
       const encoding = TextEncodingEnum[dict.Encoding as keyof typeof TextEncodingEnum];
       if (encoding === undefined) {
         throw new Error(`Cannot get glyph index for specified unicode. Unsupported text encoding '${dict.Encoding}'`);
+      }
+
+      const index = TextEncoding.getIndex(code, encoding);
+      if (index != -1) {
+        const width = dict.Widths.find(index - dict.FirstChar);
+        const advanceWidth = (width instanceof core.PDFNumeric)
+          ? width.value : 0;
+
+        return {
+          index,
+          advanceWidth,
+          unicode: [code],
+        };
+      }
+
+      return {
+        index: 0,
+        advanceWidth: 0,
+        unicode: [code],
+      };
+    }
+  };
+}
+
+function createFontInfoFromType1(dict: core.Type1FontDictionary): pdfFont.IFontInfo {
+  return {
+    ascent: dict.FontDescriptor.ascent || 0,
+    descent: dict.FontDescriptor.descent || 0,
+    unitsPerEm: 1000,
+    findGlyph: (code: number): pdfFont.IFontGlyph => {
+      if (!(dict.Encoding instanceof core.PDFName)) {
+        throw new Error("Type1FontDictionary should have Encoding field of type PDFName.");
+      }
+      const encoding = TextEncodingEnum[dict.Encoding.text as keyof typeof TextEncodingEnum];
+      if (encoding === undefined) {
+        throw new Error(`Cannot get glyph index for specified unicode. Unsupported text encoding '${dict.Encoding}'`);
+      }
+
+      if (!dict.Widths) {
+        throw new Error("Type1FontDictionary should have Widths field.");
+      }
+
+      if (dict.FirstChar === null) {
+        throw new Error("Type1FontDictionary should have FirstChar field.");
       }
 
       const index = TextEncoding.getIndex(code, encoding);
@@ -96,7 +140,7 @@ export class FontComponent extends WrapObject<core.FontDictionary> {
         if (Object.values<string>(pdfFont.DefaultFonts).includes(params.fontDictionary.BaseFont)) {
           this.fontInfo = pdfFont.FontFactory.createDefault(params.fontDictionary.BaseFont as pdfFont.DefaultFonts);
         } else {
-          throw new Error(`Cannot create fontInfo by ${params.fontDictionary.BaseFont}`);
+          this.fontInfo = createFontInfoFromType1(params.fontDictionary);
         }
       } else if (params.fontDictionary instanceof core.Type0FontDictionary) {
         const cid = params.fontDictionary.DescendantFonts.get(0, core.CIDFontDictionary);
@@ -110,7 +154,7 @@ export class FontComponent extends WrapObject<core.FontDictionary> {
         const fontDescriptor = params.fontDictionary.FontDescriptor;
         const fontFile = fontDescriptor.fontFile || fontDescriptor.fontFile2 || fontDescriptor.fontFile3;
         if (!fontFile) {
-          this.fontInfo = createFontInfo(params.fontDictionary);
+          this.fontInfo = createFontInfoFromTrueType(params.fontDictionary);
         } else {
           this.fontInfo = pdfFont.FontFactory.create(fontFile.decodeSync());
         }


### PR DESCRIPTION
This Pull Request contains two changes:

- Update Type1FontDictionary to accept a PDFName object for the Encoding field
- Update FontComponent to support creating fontInfo from Type1FontDictionary
- Fixes #57