### PR TITLE
fix: Unable to set value for Radio widget

### DIFF
--- a/packages/doc/src/Document.ts
+++ b/packages/doc/src/Document.ts
@@ -366,7 +366,7 @@ export class PDFDocument {
   }
 
   public getComponentById(id: number, generation?: number): forms.IComponent | null;
-  public getComponentById<T>(id: number, generation: number, type: new (target: any, document: PDFDocument) => T): T | null;
+  public getComponentById<T>(id: number, generation: number, type: new (target: any, document: PDFDocument) => T): T;
   public getComponentById(id: number, generation?: number, type?: typeof WrapObject): forms.IComponent | WrapObject<any> | null {
     let component: forms.IComponent | null = null;
 

--- a/packages/doc/src/forms/RadioButton.Group.ts
+++ b/packages/doc/src/forms/RadioButton.Group.ts
@@ -37,4 +37,23 @@ export class RadioButtonGroup extends FormComponentGroup<core.ButtonDictionary, 
     return null;
   }
 
+  public set selected(v: string | null) {
+    if (v !== this.selected) {
+      if (v === null) {
+        if (this.selected) {
+          try {
+            const selected = this.get(this.selected);
+            selected.checked = false;
+          } catch {
+            // ignore: sometimes the selected value of the group does not correspond to a real element
+          }
+        }
+        this.target.V = null;
+      } else {
+        const selected = this.get(v);
+        selected.checked = true;
+      }
+    }
+  }
+
 }

--- a/packages/doc/src/forms/RadioButton.ts
+++ b/packages/doc/src/forms/RadioButton.ts
@@ -23,8 +23,12 @@ export class RadioButton extends CheckBox implements IFormGroupedComponent {
       // Update filed
       if (group && group.selected && group.selected !== stateName) {
         // disable prev selected
-        const selected = group.get(group.selected);
-        selected.checked = false;
+        try {
+          const selected = group.get(group.selected);
+          selected.checked = false;
+        } catch {
+          // ignore: sometimes the selected value of the group does not correspond to a real element
+        }
       }
 
       if (group) {


### PR DESCRIPTION
### Overview
This pull request includes changes to the `PDFDocument`, `RadioButtonGroup` and `RadioButton` classes.

### Changes
- Updated the `PDFDocument.getComponentById` method to require a type parameter for non-null return values.
- Added a set selected property to the `RadioButtonGroup` class to update the selected radio button based on the new value.
- Updated the `RadioButton` class to handle cases where the selected value of the group does not correspond to a real element.
- Fixes #61