### PR TITLE
fix: incorrect BBox when changing Y coordinate

### DIFF
--- a/packages/core/src/structure/common/Rectangle.ts
+++ b/packages/core/src/structure/common/Rectangle.ts
@@ -59,7 +59,13 @@ export class PDFRectangle extends PDFArray {
     this.items = [new PDFNumeric(0), new PDFNumeric(0), new PDFNumeric(0), new PDFNumeric(0)];
   }
 
-  public getCoordinates(): Array<number> {
+  /**
+   * Returns the rectangle as an array of numbers.
+   * @returns An array of numbers in the form [llX, llY, urX, urY].
+   * @throws If the rectangle does not have 4 coordinates.
+   * @throws If any of the coordinates are not numbers.
+   */
+  public toArray(): Array<number> {
 
     if (this.items.length !== 4) {
       throw new Error("The rectangle must have 4 coordinates");

--- a/packages/doc/src/FormObject.ts
+++ b/packages/doc/src/FormObject.ts
@@ -42,10 +42,12 @@ export class FormObject extends WrapContentObject<core.FormDictionary> {
   }
 
   public set height(v: core.TypographySize) {
-    if (this.target.bBox.urY < 0) {
-      this.target.bBox.urY -= core.TypographyConverter.toPoint(v) - this.height;
-    } else {
-      this.target.bBox.urY += core.TypographyConverter.toPoint(v) - this.height;
+    if (this.height !== v) {
+      if (this.target.bBox.urY < 0) {
+        this.target.bBox.urY -= core.TypographyConverter.toPoint(v) - this.height;
+      } else {
+        this.target.bBox.urY += core.TypographyConverter.toPoint(v) - this.height;
+      }
     }
   }
 

--- a/packages/doc/src/forms/FormComponent.ts
+++ b/packages/doc/src/forms/FormComponent.ts
@@ -57,7 +57,7 @@ export class FormComponent extends WrapObject<core.WidgetDictionary> implements 
 
   public set top(v: core.TypographySize) {
     let vPt = core.TypographyConverter.toPoint(v);
-    const height = this.width;
+    const height = this.height;
 
     vPt = (this.target.p)
       ? this.target.p.to(core.PageObjectDictionary).MediaBox.urY - vPt
@@ -96,7 +96,13 @@ export class FormComponent extends WrapObject<core.WidgetDictionary> implements 
    * Gets component height
    */
   public get height(): number {
-    return this.target.rect.urY - this.target.rect.llY;
+    const rect = this.target.rect.toArray();
+    const y1 = Math.min(rect[1], rect[3]);
+    const y2 = Math.max(rect[1], rect[3]);
+
+    const height = Math.abs(y2 - y1);
+
+    return height;
   }
 
   /**

--- a/packages/doc/src/forms/TextEditor.Handler.ts
+++ b/packages/doc/src/forms/TextEditor.Handler.ts
@@ -13,6 +13,10 @@ export interface BorderParameters {
   height: number;
 }
 export interface TextEditorCreateParameters {
+  /**
+   * Name of the field
+   */
+  name?: string;
   left?: core.TypographySize;
   top?: core.TypographySize;
   /**
@@ -98,7 +102,17 @@ export class TextEditorHandler implements ITextEditorHandler {
       // Clip rec
       .rect(padding, padding, form.width - padding * 2, form.height - padding * 2)
       .clip()
-      .pathEnd()
+
+      // draw background
+      // .rect(0, 0, form.width, form.height)
+      // .fillColor([0.5, 0.5, 0.5])
+      // .fill()
+
+      // draw clip rectangle
+      // .rect(padding, padding, form.width - padding * 2, form.height - padding * 2)
+      // .fillColor([0.8, 0.8, 0.8])
+      // .fill()
+
       .text();
 
     if (params.multiline) {
@@ -159,9 +173,12 @@ export class TextEditorHandler implements ITextEditorHandler {
       const text = this.getSingleLineText(params.text);
       textContent.show(text);
     }
+
+    // console.log(form.target.content.toString());
   }
 
   public create(params: TextEditorCreateParameters): core.WidgetDictionary {
+    const doc = this.document.target;
 
     let text = params.text;
     if (params.maxLen && params.maxLen > 0) {
@@ -196,8 +213,8 @@ export class TextEditorHandler implements ITextEditorHandler {
     }
 
     widget.set("MaxLen", new core.PDFNumeric(params.maxLen || TextEditorHandler.MAX_LEN));
-    widget.t = this.document.target.createString(core.UUID.generate());
-    widget.V = this.document.target.createString(text);
+    widget.t = params.name ? doc.createString(params.name) : doc.createString(core.UUID.generate());
+    widget.V = doc.createString(text);
     widget.rect.llX = positionX;
     widget.rect.llY = positionY;
     widget.rect.urX = positionX + width;
@@ -208,7 +225,7 @@ export class TextEditorHandler implements ITextEditorHandler {
     const fontRes = yes.resources.set(params.font.target);
     const da = new core.PDFContent().setFontAndSize({ font: fontRes.name, size: fontSize });
     da.setColor(params.color);
-    widget.set("DA", this.document.target.createString(da.toString(true)));
+    widget.set("DA", doc.createString(da.toString(true)));
 
     // Draw
     this.drawText(yes, {


### PR DESCRIPTION
## Changes
- `Rectangle.ts`: Added a new function `toArray()` that returns the rectangle as an array of numbers.
- `FormObject.ts`: Updated the setter function for the height property, so that it only adjusts the height if the new value is different from the current value.
- `FormComponent.ts`: Updated the `height()` function to calculate the height of the component correctly by taking into account the Y coordinates of the bounding rectangle.
- `TextEditor.Handler.ts`: Added a new parameter called `name` to the `create()` function, which allows specifying the name of the field. Also added some commented-out code to draw a background and clip rectangle.
