### PR TITLE
feat: support page padding

### DIFF
--- a/packages/doc/src/Page.spec.ts
+++ b/packages/doc/src/Page.spec.ts
@@ -1066,4 +1066,27 @@ context("Page", () => {
 
   });
 
+  it("Padding", async () => {
+    const doc = await PDFDocument.create(options);
+
+    const page = doc.pages.create({
+      width: 200,
+      height: 400,
+    });
+
+    page.leftPadding = 10;
+    page.topPadding = 15;
+    page.rightPadding = 20;
+    page.bottomPadding = 25;
+
+    assert.strictEqual(page.target.CropBox?.llX, 10);
+    assert.strictEqual(page.leftPadding, 10);
+    assert.strictEqual(page.target.CropBox?.llY, 25);
+    assert.strictEqual(page.bottomPadding, 25);
+    assert.strictEqual(page.target.CropBox?.urX, 180);
+    assert.strictEqual(page.rightPadding, 20);
+    assert.strictEqual(page.target.CropBox?.urY, 385);
+    assert.strictEqual(page.topPadding, 15);
+  });
+
 });

--- a/packages/doc/src/Page.ts
+++ b/packages/doc/src/Page.ts
@@ -88,6 +88,46 @@ export class PDFPage extends WrapContentObject<core.PageObjectDictionary> {
     return this.target.MediaBox.llY;
   }
 
+  public get leftPadding(): number {
+    return this.target.CropBox?.llX || 0;
+  }
+
+  public set leftPadding(value: core.TypographySize) {
+    this.getOrCreateCropBox().llX = core.TypographyConverter.toPoint(value);
+  }
+
+  public get rightPadding(): number {
+    return this.width - (this.target.CropBox?.urX || 0);
+  }
+
+  public set rightPadding(value: core.TypographySize) {
+    this.getOrCreateCropBox().urX = this.width - core.TypographyConverter.toPoint(value);
+  }
+
+  public get topPadding(): number {
+    return this.height - (this.target.CropBox?.urY || 0);
+  }
+
+  public set topPadding(value: core.TypographySize) {
+    this.getOrCreateCropBox().urY = this.height - core.TypographyConverter.toPoint(value);
+  }
+
+  public get bottomPadding(): number {
+    return this.target.CropBox?.llY || 0;
+  }
+
+  public set bottomPadding(value: core.TypographySize) {
+    this.getOrCreateCropBox().llY = core.TypographyConverter.toPoint(value);
+  }
+
+  protected getOrCreateCropBox(): core.PDFRectangle {
+    if (!this.target.CropBox) {
+      this.target.CropBox = this.document.target.createRectangle(0, 0, this.width, this.height);
+    }
+
+    return this.target.CropBox;
+  }
+
   public addCheckBox(params: forms.ICheckBoxCreateParameters = {}): forms.CheckBox {
     params.top = this.height - core.TypographyConverter.toPoint(params.top || 0);
 


### PR DESCRIPTION
Example

```ts
const page = doc.pages.create({
  width: 200,
  height: 400,
});

page.leftPadding = "10cm";
page.topPadding = "15mm";
page.rightPadding = "20px";
page.bottomPadding = 25;
```