### PR TITLE
fix: split single widget for signature box

### DIFF
--- a/packages/core/src/forms/Field.ts
+++ b/packages/core/src/forms/Field.ts
@@ -1,5 +1,6 @@
 import * as objects from "../objects";
 import { PDFDictionary } from "../objects";
+import type { WidgetDictionary } from "../structure/dictionaries/Widget";
 import { AdditionalActionsDictionary } from "../structure/dictionaries/AdditionalActionsDictionary";
 import { UUID } from "../UUID";
 
@@ -182,7 +183,7 @@ export class PDFField extends objects.PDFDictionary implements IFieldDictionary 
     this.t = document.createString(UUID.generate());
   }
 
-  public addKid(kid: IFieldDictionary): void {
+  public addKid(kid: IFieldDictionary | WidgetDictionary): void {
     this.modify().Kids.get().push(kid.makeIndirect());
     kid.Parent = this.makeIndirect();
   }

--- a/packages/doc/src/forms/SignatureBox.Handler.ts
+++ b/packages/doc/src/forms/SignatureBox.Handler.ts
@@ -2,6 +2,7 @@ import * as core from "@peculiarventures/pdf-core";
 import { SignatureBoxGroup } from "./SignatureBox.Group";
 import { PDFDocument } from "../Document";
 import { FormComponentHandler, IFormComponentCreateParameters, IFormComponentHandler, IFormComponentParameters } from "./FormComponent.Handler";
+import { SignatureBox } from "./SignatureBox";
 
 export interface ISignatureBoxCreateParameters extends IFormComponentCreateParameters {
   groupName?: string;
@@ -30,11 +31,14 @@ export class SignatureBoxHandler extends FormComponentHandler implements ISignat
     return new SignatureBoxGroup(field, this.document);
   }
 
+
   public getOrCreateGroup(name: string): SignatureBoxGroup {
     let group = this.document.getComponentByName(name);
     if (!group) {
       // Create new group
       group = this.createGroup(name);
+    } else if (group instanceof SignatureBox) {
+      group = group.split();
     }
 
     if (!(group instanceof SignatureBoxGroup)) {


### PR DESCRIPTION
This pull request includes changes to three files: `Field.ts`, `SignatureBox.Handler.ts`, and `SignatureBox.ts`. Let's go through the changes in each file:

**Field.ts:**
- An import statement is added for the `WidgetDictionary` from the `../structure/dictionaries/Widget` module.

- The method `addKid` is modified to accept an additional parameter `kid` of type `WidgetDictionary` besides `IFieldDictionary`.

**SignatureBox.Handler.ts:**
- An import statement is added for the `SignatureBox` class from the `./SignatureBox` module.

- The method `getOrCreateGroup` is modified to handle the case where the group already exists but is an instance of `SignatureBox`. In this case, the group is split by calling the `split` method.

**SignatureBox.ts:**
- The `set groupName` setter method is modified to call the `split` method before attaching the signature box to a group. This ensures that the signature box is split into a widget and a field with kids before attaching it to a group.

- Two new methods, `isSingleWidget` and `split`, are added to the `SignatureBox` class.

  - `isSingleWidget` checks if the widget is a single widget (Field + Widget) by checking the presence of the "FT" key.

  - `split` is used to split a single widget (Field + Widget) into a widget and a field with kids. If the widget is already part of a group, it returns the group. Otherwise, it creates a new group, moves the widget to it, and returns the new group.

These changes introduce new functionality related to the splitting of single widgets into separate components and managing groups in the context of signature boxes.