### PR TITLE
Fix incorrect signature removing

### DIFF
--- a/packages/core/src/forms/Field.ts
+++ b/packages/core/src/forms/Field.ts
@@ -204,4 +204,16 @@ export class PDFField extends objects.PDFDictionary implements IFieldDictionary 
     return parts.join(".");
   }
 
+  public remove(): void {
+    const parent = this.Parent;
+    if (parent) {
+      parent.modify();
+      const kids = parent.Kids.get();
+      const index = kids.indexOf(this);
+      if (index >= 0) {
+        kids.splice(index, 1);
+      }
+    }
+  }
+
 }

--- a/packages/doc/src/forms/FormComponent.ts
+++ b/packages/doc/src/forms/FormComponent.ts
@@ -378,12 +378,33 @@ export class FormComponent extends WrapObject<core.WidgetDictionary> implements 
   }
 
   public delete(): void {
-    const parent = this.target.p;
-    if (parent && parent.annots) {
-      const index = parent.annots.indexOf(this.target);
+    this.deleteFromPage();
+    this.deleteFromField();
+  }
+
+  /**
+   * Delete annotation from page
+   */
+  private deleteFromPage() {
+    const page = this.target.p;
+    if (page && page.annots) {
+      const index = page.annots.indexOf(this.target);
       if (index !== -1) {
-        parent.annots.splice(index, 1);
+        page.annots.splice(index, 1);
       }
+    }
+  }
+
+  private deleteFromField() {
+    const field = this.getField();
+    if (!field.Kids.has()) {
+      return;
+    }
+
+    const kids = field.Kids.get();
+    const index = kids.indexOf(this.target);
+    if (index !== -1) {
+      kids.splice(index, 1);
     }
   }
 

--- a/packages/doc/src/forms/SignatureBox.ts
+++ b/packages/doc/src/forms/SignatureBox.ts
@@ -164,4 +164,24 @@ export class SignatureBox extends FormComponent implements IFormGroupedComponent
     return new SignatureBoxGroup(newField, this.document);
   }
 
+  public override delete(): void {
+    super.delete();
+
+    // if field has no kids, delete it
+    const field = this.getField();
+    if (!field.Kids.has() || field.Kids.get().length === 0) {
+      field.remove();
+    }
+
+    // if document doesn't have any signature fields, remove remove SigFlags
+    const signatures = this.document.getSignatures();
+    if (signatures.length === 0) {
+      const maybeAcroForm = this.document.target.update.catalog!.AcroForm;
+      if (maybeAcroForm.has()) {
+        const acroForm = maybeAcroForm.get();
+        acroForm.delete("SigFlags");
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #90

Thi fix improves signature removing from PDF document.

Now signature removing looks like

- Remove Signature Annotation from page
- Remove Signature Annotation from Fields
- If Signature Filed doesn't have any other annotation, remove it
- If PDF document doesn't have any other signature fields, remove SigFlags from document