### PR TITLE
fix: incorrect stream cloning

### DIFF
--- a/packages/copy/src/copier.ts
+++ b/packages/copy/src/copier.ts
@@ -210,7 +210,9 @@ export class PDFCopier {
       return ref;
     }
 
-    const res = this.document.createStream();
+    const res = new core.PDFStream();
+    res.documentUpdate = this.document.update;
+    res.makeIndirect();
     map.set(target.getIndirect(), res);
 
     res.set("Length", this.document.createNumber(0));


### PR DESCRIPTION
Stream cloning replaces original `Filters` and doesn't reencode the stream value. This update fixes it by reusing the same Filters from the original stream