### PR TITLE
fix: use User password for Owner if Owner is empty

### DIFF
--- a/packages/core/src/encryption/StandardEncryptionHandler.spec.ts
+++ b/packages/core/src/encryption/StandardEncryptionHandler.spec.ts
@@ -137,6 +137,14 @@ context("StandardEncryptionHandler", () => {
           },
         },
         {
+          name: "AES256 U:1235",
+          params: {
+            file: "aes256_u1235",
+            algorithm: CryptoFilterMethods.AES256,
+            userPassword: "12345",
+          },
+        },
+        {
           name: "AES256 U:12345, O:54321",
           params: {
             file: "aes256_u12345_o54321",

--- a/packages/core/src/encryption/StandardEncryptionHandler.ts
+++ b/packages/core/src/encryption/StandardEncryptionHandler.ts
@@ -43,7 +43,9 @@ export class StandardEncryptionHandler extends EncryptionHandler {
 
     // params
     const userPassword = params.userPassword || "";
-    const ownerPassword = params.ownerPassword || crypto.getRandomValues(new Uint8Array(16));
+    // YOLO: Mirroring the Acrobat behavior here. If the owner password is not
+    // provided, the user password is used instead.
+    const ownerPassword = params.ownerPassword || userPassword;
     const permissions = params.permission || 0;
 
     // create Encrypt dictionary


### PR DESCRIPTION
Mirroring the Acrobat behavior for Encryption handler. If the owner password is not provided, the user password should be used instead.