### PR TITLE
Improved border handling for TextEditor component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         if: env.PREV_VERSION != env.CURRENT_VERSION
         with:
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/packages/doc/src/forms/ComboBox.Handler.ts
+++ b/packages/doc/src/forms/ComboBox.Handler.ts
@@ -66,6 +66,21 @@ export class ComboBoxHandler implements IComboBoxHandler {
 
     const dict = core.SingleWidgetDictionary.create(update);
 
+    if (params.borderWidth) {
+      const bs = dict.BS.get();
+      bs.W = core.TypographyConverter.toPoint(params.borderWidth);
+
+      if (params.borderColor) {
+        const mk = dict.MK.get();
+        mk.BC = core.ColorConverter.toPDFArray(params.borderColor);
+      }
+    }
+
+    if (params.backgroundColor) {
+      const mk = dict.MK.get();
+      mk.BG = core.ColorConverter.toPDFArray(params.backgroundColor);
+    }
+
     dict.ft = "Ch";
 
     const _widget = dict.to(core.WidgetDictionary);
@@ -99,7 +114,7 @@ export class ComboBoxHandler implements IComboBoxHandler {
 
     // draw border
     const formContent =
-      borderWidth > 0
+      component.target.BS.has() && component.target.BS.get().W > 0
         ? form
             .graphics()
             .strokeColor(component.borderColor)

--- a/packages/doc/src/forms/ComboBox.spec.ts
+++ b/packages/doc/src/forms/ComboBox.spec.ts
@@ -28,6 +28,34 @@ describe("ComboBox", () => {
     docRaw = await doc.save();
   });
 
+  it("draw without border", async () => {
+    const doc = await PDFDocument.create(xrefTableOptions);
+    const page = doc.pages.create();
+
+    page.addComboBox({
+      left: 10,
+      top: 10,
+      width: 140,
+      height: 20,
+      name: "comboBox1",
+      options: {
+        item1: "Item 1",
+        item2: "Item 2",
+        item3: "Item 3"
+      },
+      selected: "item2"
+    });
+
+    const pdf = await doc.save();
+    const pageHash = await PdfRenderingHelper.getPageHash(pdf, 1);
+    const expectedHash: Record<string, string> = {
+      darwin:
+        "fba4ec049cc1b4de55812907a832f612826c028486e014e3717d75e9e75452de",
+      linux: "a9124757eac250d1f5d1eb0d728212f07a63ac583b38ebe5f087477440697dad"
+    };
+    expect(pageHash).toBe(expectedHash[process.platform]);
+  });
+
   it("draw", async () => {
     const pageHash = await PdfRenderingHelper.getPageHash(docRaw, 1);
     const expectedHash: Record<string, string> = {

--- a/packages/doc/src/forms/TextEditor.Handler.ts
+++ b/packages/doc/src/forms/TextEditor.Handler.ts
@@ -276,7 +276,8 @@ export class TextEditorHandler implements ITextEditorHandler {
     widget.set("DA", doc.createString(da.toString(true)));
 
     if (params.borderWidth) {
-      widget.BS.get();
+      const bs = widget.BS.get();
+      bs.W = core.TypographyConverter.toPoint(params.borderWidth);
       const mk = widget.MK.get();
       mk.BC = core.ColorConverter.toPDFArray(
         params.borderColor ?? TextEditorHandler.BORDER_COLOR

--- a/packages/doc/src/forms/TextEditor.Handler.ts
+++ b/packages/doc/src/forms/TextEditor.Handler.ts
@@ -33,6 +33,7 @@ export interface TextEditorCreateParameters {
   height: core.TypographySize;
   borderColor?: core.Colors;
   borderWidth?: core.TypographySize;
+  backgroundColor?: core.Colors;
   /**
    * Max count symbols
    */
@@ -273,6 +274,21 @@ export class TextEditorHandler implements ITextEditorHandler {
     });
     da.setColor(params.color);
     widget.set("DA", doc.createString(da.toString(true)));
+
+    if (params.borderWidth) {
+      widget.BS.get();
+      const mk = widget.MK.get();
+      mk.BC = core.ColorConverter.toPDFArray(
+        params.borderColor ?? TextEditorHandler.BORDER_COLOR
+      );
+    }
+
+    if (params.backgroundColor) {
+      const mk = widget.MK.get();
+      mk.BG = core.ColorConverter.toPDFArray(
+        params.backgroundColor ?? TextEditorHandler.BACKGROUND_COLOR
+      );
+    }
 
     // Draw
     this.drawText(

--- a/packages/doc/src/forms/TextEditor.spec.ts
+++ b/packages/doc/src/forms/TextEditor.spec.ts
@@ -28,6 +28,34 @@ describe("TextEditor", () => {
     docRaw = await doc.save();
   });
 
+  it("draw default", async () => {
+    const doc = await PDFDocument.create(xrefTableOptions);
+    const page = doc.pages.create();
+
+    const helvetica = doc.addFont(DefaultFonts.Helvetica);
+
+    page.addTextEditor({
+      left: 10,
+      top: 10,
+      width: 200,
+      height: 30,
+      name: "textEditor1",
+      text: "Test example",
+      fontSize: 12,
+      font: helvetica
+    });
+
+    const pdf = await doc.save();
+
+    const pageHash = await PdfRenderingHelper.getPageHash(pdf, 1);
+    const expectedHash: Record<string, string> = {
+      darwin:
+        "6d60b897a3a1d4d0a2c9f3e8cfd80d8ac35575e768339213e463888ef04a8e5e",
+      linux: "06664973078ee8281ced8234534b7024d2e9e2ba3eeaea18406be91df34bb9b6"
+    };
+    expect(pageHash).toBe(expectedHash[process.platform]);
+  });
+
   it("draw", async () => {
     const pageHash = await PdfRenderingHelper.getPageHash(docRaw, 1);
 

--- a/packages/doc/src/forms/TextEditor.ts
+++ b/packages/doc/src/forms/TextEditor.ts
@@ -277,12 +277,26 @@ export class TextEditor extends FormComponent {
         maxLen: this.maxLen,
 
         width: this.width,
-        height: this.height,
-
-        backgroundColor: this.backgroundColor,
-        borderColor: this.borderColor,
-        borderWidth: this.borderWidth
+        height: this.height
       };
+
+      if (this.target.BS.has()) {
+        const bs = this.target.BS.get();
+        params.borderWidth = bs.W;
+        if (this.target.MK.has()) {
+          const mk = this.target.MK.get();
+          if (mk.BC) {
+            params.borderColor = core.ColorConverter.fromPDFArray(mk.BC);
+          }
+        }
+      }
+
+      if (this.target.MK.has()) {
+        const mk = this.target.MK.get();
+        if (mk.BG) {
+          params.backgroundColor = core.ColorConverter.fromPDFArray(mk.BG);
+        }
+      }
 
       const handler = this.document.textEditorHandler;
       form.clear();

--- a/packages/form-json/src/FormConverter.spec.ts
+++ b/packages/form-json/src/FormConverter.spec.ts
@@ -212,8 +212,8 @@ describe("FormConverter", () => {
 
     const expectedHash: Record<string, string> = {
       darwin:
-        "ba8e2842155e1105bcc3d674930fb354eb0913492ba8264a06293e50b0245603",
-      linux: "1f025cb5eeae5f8c36faade8ae5aaf75cb882ebc8216318bea621a132cecc06e"
+        "21b6a49b6f63b74cafc33c475ae1757b95ae8965a6d6df65f7d0dc10d33344fa",
+      linux: "92cc24f6ccce7a1a19102235aad77341539d7795c0cb250043129e6be49aa525"
     };
     expect(hash).toBe(expectedHash[process.platform]);
   });
@@ -252,8 +252,8 @@ describe("FormConverter", () => {
 
     const expectedHash: Record<string, string> = {
       darwin:
-        "492b15b25d4ad68f09d751af166ece97f91fe23bbcce5730dfba60a72b8fa8d0",
-      linux: "78a67a9d1d1d787b15bdde8dc4d23312365a8a377de60c9fdb6b53ed512b4a29"
+        "8194df0596ccb08a2710af0bd848eefb8ee1d8fcc6f052519fef685d5d2a08c2",
+      linux: "a8db93dbb796d32fd44ea1b30da8f745b7ba6274d6138f8243d169ca087c6386"
     };
     expect(hash).toBe(expectedHash[process.platform]);
   });


### PR DESCRIPTION
This update addresses an issue with border rendering for the `TextEditor` component.

**Previously:**
- If border parameters were not explicitly defined when adding a `TextEditor`, the application would default to drawing a black border around it.

**Now:**
- The `TextEditor` component will **no longer draw a default border** if border parameters are not specified.
- A border will only be rendered if it is **explicitly defined** for the `TextEditor`.

**Example of creating a `TextEditor` without a default border:**

```typescript
const doc = await PDFDocument.create(xrefTableOptions);
const page = doc.pages.create();

const helvetica = doc.addFont(DefaultFonts.Helvetica);

page.addTextEditor({
  left: 10,
  top: 10,
  width: 200,
  height: 30,
  name: "textEditor1",
  text: "Test example",
  fontSize: 12,
  font: helvetica
});
```

**Resulting Page View:**

<img width="414" alt="image" src="https://github.com/user-attachments/assets/e34d099b-ef71-4c34-a557-9096361cecd0" />
